### PR TITLE
modify domain with no data response problem

### DIFF
--- a/src/utils/fc/trigger.js
+++ b/src/utils/fc/trigger.js
@@ -60,6 +60,9 @@ class Trigger extends Client {
             resolve(undefined)
           }
         })
+        res.on('end', function () {
+          resolve("emptyData")
+        })
       })
       req.on('error', function (e) {
         resolve(undefined)


### PR DESCRIPTION
当部署的域名访问不返回 data 时，deploy 流程会在部署触发器那块中断，后续流程不会再执行，原因是在 src/utils/fc/trigger.js 中的方法 getAutoDomainState 中，未在 res.on('end') 中 resolve，导致该函数一直为未结束状态。