### PR TITLE
add nas sync log

### DIFF
--- a/readme_en.md
+++ b/readme_en.md
@@ -83,6 +83,8 @@ MyFunction:
 #      Nas: Auto
 #      Nas:
 #        Type: Auto
+#        UserId: 33
+#        GroupId: 33
 #        FcDir: /home/aaaaaa
 #        LocalDir: ./ssss
 #        LocalDir: 
@@ -286,6 +288,8 @@ MyFunction:
 | Type | True | Enum | Automatic configuration |
 | FcDir | False | String | Function calculation directory |
 | LocalDir | False | String[Single directory]/List<String>[Multi directory configuration] | Local directory |
+| UserId | False | String | userID |
+| GroupId | False | String | groupID |
 
 #### MountPoints
 | Name |  Required  |  Type  |  Description  |

--- a/readme_zh.md
+++ b/readme_zh.md
@@ -76,6 +76,8 @@ MyFunction:
 #      Nas: Auto
 #      Nas:
 #        Type: Auto
+#        UserId: 33
+#        GroupId: 33
 #        FcDir: /home/aaaaaa
 #        LocalDir: ./ssss
 #        LocalDir: 
@@ -279,6 +281,8 @@ MyFunction:
 | Type | True | Enum | 自动化配置 |
 | FcDir | False | String | 函数计算目录 |
 | LocalDir | False | String[单一目录]/List<String>[多目录配置] | 本地目录 |
+| UserId | False | String | userID |
+| GroupId | False | String | groupID |
 
 #### MountPoints
 | 参数名 |  必填  |  类型  |  参数描述  |

--- a/src/utils/fc/nas.js
+++ b/src/utils/fc/nas.js
@@ -68,6 +68,7 @@ class Nas {
         throw new Error('Input error.')
       }
       if (this.serviceProp.Nas === 'Auto' || this.serviceProp.Nas.Type === 'Auto') {
+        this.logger.log(`Sync ${syncLocalDirs} to ${this.serviceProp.Nas.FcDir}`)
         await this.syncAuto(cmdArgs.noOverwirte, syncLocalDirs, this.serviceProp.Nas.FcDir)
       } else {
         await this.syncNonAuto(cmdArgs.alias, cmdArgs.noOverwirte, syncLocalDirs)


### PR DESCRIPTION
目前 nas type 设置为 Auto 时，是支持指定 UserId 和 GroupId 的，具体如下图所示：

![image](https://user-images.githubusercontent.com/52195264/102219086-ebef6880-3f19-11eb-885a-9ce3054ef341.png)

主要更新了 readme 中 nas auto 的用法。
